### PR TITLE
Synopsys: Automated PR: Update mongoose/4.2.4 to 4.13.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "method-override": "latest",
     "moment": "2.15.1",
     "mongodb": "^3.5.9",
-    "mongoose": "4.2.4",
+    "mongoose": "4.13.21",
     "morgan": "latest",
     "ms": "^0.7.1",
     "mysql": "^2.18.1",


### PR DESCRIPTION
## Vulnerabilities associated with mongoose/4.2.4
[BDSA-2023-1810](https://openhub.net/vulnerabilities/bdsa/BDSA-2023-1810) *(CRITICAL)*: Mongoose is vulnerable to a prototype pollution issue due to a lack of sufficient input validation when setting the schema object. An attacker could inject a malicious payload containing a modified `Object.prototype` entry in order to potentially cause Mongoose to execute untrusted code or crash outright.

[Click Here To See More Details On Server](https://us03-qa-hub11.nprd.sig.synopsys.com/api/projects/6dc3ec82-4554-41c0-b839-4f1a929ce315/versions/f9184810-1396-4347-b229-295ed7695055/vulnerability-bom?selectedItem=4139d8b8-dde0-427b-a35b-9eb4c8a46f2f)