### PR TITLE
Synopsys: Automated PR: Update typeorm/0.2.24 to 0.3.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "st": "0.2.4",
     "stream-buffers": "^3.0.1",
     "tap": "^11.1.3",
-    "typeorm": "^0.2.24",
+    "typeorm": "^0.3.17",
     "validator": "^13.5.2",
     "webpack": "^5.88.2"
   },


### PR DESCRIPTION
## Vulnerabilities associated with typeorm/0.2.24
[BDSA-2022-4090](https://openhub.net/vulnerabilities/bdsa/BDSA-2022-4090) *(HIGH)*: TypeORM is vulnerable to SQL injection (SQLi) due to improper validation of user-supplied input. This could allow an unauthenticated attacker to execute malicious SQL statements to alter or retrieve information stored on the application's databases.

**Note:** A further report [here](https://seclists.org/fulldisclosure/2022/Aug/7) has indicated that the fix for this vulnerability introduces a further information disclosure issue. It should be noted that the maintainer does not consider either report as valid vulnerabilities and stated the root cause is bad input validation. The CVE is currently being disputed.

[BDSA-2020-2484](https://openhub.net/vulnerabilities/bdsa/BDSA-2020-2484) *(HIGH)*: TypeORM is vulnerable to SQL injection and denial-of-service (DoS) by way of prototype pollution. Success full exploitation of this issue could also allow remote code execution on the target system.

[Click Here To See More Details On Server](https://us03-qa-hub11.nprd.sig.synopsys.com/api/projects/6dc3ec82-4554-41c0-b839-4f1a929ce315/versions/f9184810-1396-4347-b229-295ed7695055/vulnerability-bom?selectedItem=c92909de-14c5-4499-8c2e-9de1dd6e451b)